### PR TITLE
Update typings to make config optional

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,4 +5,4 @@ export interface IMobXLoggerConfig {
     transaction?: boolean;
     compute?: boolean;
 }
-export function enableLogging(config: IMobXLoggerConfig): void
+export function enableLogging(config?: IMobXLoggerConfig): void


### PR DESCRIPTION
Since there is default config available there's no need to supply a config unless you want to.